### PR TITLE
Added PREFER_LINE_BREAKS setting,

### DIFF
--- a/src/scripts/namespace.coffee
+++ b/src/scripts/namespace.coffee
@@ -40,6 +40,12 @@ window.ContentEdit =
     # more than a 1/4 of the total size.
     RESIZE_CORNER_SIZE: 15
 
+    # The default behaviour is to start a new <p> tag whenever the Enter(Return) key is pressed.
+    # Ctrl+Enter creates a line break inside the current element instead.
+    # By toggling this setting to `true`, this behaviour is flipped: Enter will create line breaks,
+    # while Ctrl+Enter will start a new <p> tag.
+    PREFER_LINE_BREAKS: false 
+
     # Translation - the ContentEdit library provides basic translation support
     # which is used both by the library itself and the associated ContentTools
     # library.

--- a/src/scripts/text.coffee
+++ b/src/scripts/text.coffee
@@ -326,7 +326,7 @@ class ContentEdit.Text extends ContentEdit.Element
 
         # If the shift key is held down then insert a line-break instead of
         # creating a new paragraph
-        if ev.shiftKey
+        if ev.shiftKey ^ ContentEdit.PREFER_LINE_BREAKS
             insertAt = selection.get()[0]
 
             # Check if this is the last character in the row


### PR DESCRIPTION
This pull-request is related to this issue on the ContentTools library: 
https://github.com/GetmeUK/ContentTools/issues/150

It adds the PREFER_LINE_BREAKS setting that swaps the way Enter and Shift+Enter behave.