### PR TITLE
Added prev/next navigation support for text, images, video.  Fixed Firefox spurious br tag insertion issue.

### DIFF
--- a/src/scripts/bases.coffee
+++ b/src/scripts/bases.coffee
@@ -161,6 +161,12 @@ class ContentEdit.Node
         return @nextWithTest (node) ->
             node.content != undefined
 
+    nextNavigable: () ->
+        # Return the next node that supports a navigate property (e.g
+        # `ContentEdit.Text`).
+        return @nextWithTest (node) ->
+            node.navigate != undefined
+
     nextSibling: () ->
         # Return the nodes next sibling
         index = @parent().children.indexOf(this)
@@ -216,6 +222,11 @@ class ContentEdit.Node
         # Return the previous node that supports a content property (e.g
         # `ContentEdit.Text`).
         node = @previousWithTest (node) -> node.content != undefined
+
+    previousNavigable: () ->
+        # Return the previous node that supports a navigate property (e.g
+        # `ContentEdit.Text`).
+        node = @previousWithTest (node) -> node.navigate != undefined
 
     previousSibling: () ->
         # Return the nodes previous sibling

--- a/src/scripts/images.coffee
+++ b/src/scripts/images.coffee
@@ -15,6 +15,9 @@ class ContentEdit.Image extends ContentEdit.ResizableElement
         size = @size()
         @_aspectRatio = size[1] / size[0]
 
+        # Allow image elements to be nagivated to.
+        @navigate = true
+
     # Read-only properties
 
     cssTypeName: () ->

--- a/src/scripts/videos.coffee
+++ b/src/scripts/videos.coffee
@@ -20,6 +20,9 @@ class ContentEdit.Video extends ContentEdit.ResizableElement
         size = @size()
         @_aspectRatio = size[1] / size[0]
 
+        # Allow video elements to be nagivated to.
+        @navigate = true
+
     # Read-only properties
 
     cssTypeName: () ->


### PR DESCRIPTION
This adds improved keyboard navigation "to" support for text, images, and video.  That is, navigating to non-text elements.  Navigating away "from" images and video is a separate commit.

This also fixes the navigation issue in Firefox for spurious 'br' tags.

Partially fixes some of the issues in https://github.com/GetmeUK/ContentTools/issues/487