### PR TITLE
Avoid deleting "empty" elements with defined attributes

### DIFF
--- a/src/scripts/text.coffee
+++ b/src/scripts/text.coffee
@@ -42,7 +42,7 @@ class ContentEdit.Text extends ContentEdit.Element
 
         if @content.isWhitespace() and @can('remove') and 
                 (k for own k in @_attributes).length == 0
-            # Detatch element from parent if empty and has no attributes.
+            # Detatch element from parent if it has neither children nor attributes.
             
             if @parent()
                 @parent().detach(this)

--- a/src/scripts/text.coffee
+++ b/src/scripts/text.coffee
@@ -40,8 +40,10 @@ class ContentEdit.Text extends ContentEdit.Element
         if @isMounted()
             @_syncContent()
 
-        if @content.isWhitespace() and @can('remove')
-            # Detatch element from parent if empty
+        if @content.isWhitespace() and @can('remove') and 
+                (k for own k in @_attributes).length == 0
+            # Detatch element from parent if empty and has no attributes.
+            
             if @parent()
                 @parent().detach(this)
 


### PR DESCRIPTION
An element without children might still have attributes defined.  Example: in bootstrap, you might to do something like this:
```html
<span class="glyphicon glyphicon-music"></span>
```
This is an "empty" element if you're only counting how many children it has, but its attributes are very "full" 